### PR TITLE
Fix stateful keygen flag for liboqs 0.13.1-dev

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
     containing the (major, minor, patch) versions
 - A warning is issued only if the liboqs-python version's major and minor
   numbers differ from those of liboqs, ignoring the patch version
+- Updated stateful signature build flag to `-DOQS_ENABLE_SIG_STFL_KEYGEN=ON`
+  to support liboqs 0.13.1-dev
 
 # Version 0.12.0 - January 15, 2025
 

--- a/oqs/oqs.py
+++ b/oqs/oqs.py
@@ -158,10 +158,9 @@ def _install_liboqs(
                 "-DOQS_ENABLE_SIG_STFL_LMS=ON",  # LMS family
                 "-DOQS_ENABLE_SIG_STFL_XMSS=ON",  # XMSS family
                 "-DOQS_ENABLE_SIG_STFL_XMSSMT=ON",
-                # XMSS-MT family:
-                # Flag removed in the 0.13.1-dev release, but kept for compatibility.
-                # To support key-generation.
-                "-DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON",
+                # XMSS-MT family. Key-generation support flag renamed in
+                # liboqs 0.13.1-dev.
+                "-DOQS_ENABLE_SIG_STFL_KEYGEN=ON",
                 f"-DCMAKE_INSTALL_PREFIX={target_directory}",
             ],
         )


### PR DESCRIPTION
## Summary
- update build flag to `-DOQS_ENABLE_SIG_STFL_KEYGEN=ON`
- document the stateful keygen flag change in `CHANGES.md`

## Testing
- `python3 -m pytest -q` *(fails: could not install liboqs)*

------
https://chatgpt.com/codex/tasks/task_e_68491d0eaa708333b428181a24da17ca